### PR TITLE
Add Mini-Tools.uk Image Color Picker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,8 @@ with AI-Powered Palette Generator.
 - [Color Wheel](https://colorwheel.co/) - A color wheel based on the drawings by Goethe, Johann Wolfgang von from the year 1810.
 - [RGB HEX Code](https://rgbhexcode.com/) - HTML/CSS Color Picker & Converter.
 
+- [Mini-Tools.uk Image Color Picker](https://mini-tools.uk/color-picker) - Pick colors from images or screenshots, crop small areas, and copy HEX, RGB or HSL values.
+
 ## Color Palettes
 - [ColorHunt](http://colorhunt.co/) - Color palettes with quick preview feature.
 - [Swiss Style Color Picker](http://www.swisscolors.net/) - Color palettes collection.


### PR DESCRIPTION
Hi, I?d like to add Mini-Tools.uk Image Color Picker to the Web App section.

Self-recommendation: I built and use this small color picker myself. It is for grabbing exact colors from screenshots, mockups, or UI references without opening a heavy design tool.

The workflow is simple: open an image, crop a small area if needed, pick a color, and copy the HEX/RGB/HSL value.