### PR TITLE
Add PaletteCSS to color palette tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,8 @@ with AI-Powered Palette Generator.
 - [InclusiveColors](https://www.inclusivecolors.com/) - Create custom accessible Tailwind-style color palettes, with WCAG/APCA contrast checks and live previews on a mockup.
 - [ColorMagic](https://colormagic.app) - Generate color palettes with AI. Enter any keyword and generate a matching color palette.
 - [Magic Gradient](https://magicgradient.com) - Generate gradients from any keyword with AI.
+- [PaletteCSS](https://palettecss.com) - Browse and copy color palettes and CSS gradients with ready-to-use hex, CSS, and Tailwind values.
+
 
 ## Articles
 - [Trendy Web Color Palettes and Material Design Color Schemes & Tools](http://www.awwwards.com/trendy-web-color-palettes-and-material-design-color-schemes-tools.html?utm_source=Twitter&utm_medium=Social&utm_campaign=Twitter-Blog-Color&utm_content=Twitter)


### PR DESCRIPTION
Adds PaletteCSS (https://palettecss.com), a free tool to browse and copy color palettes and CSS gradients with ready-to-use hex, CSS, and Tailwind values.

- Added in alphabetical order in the relevant section
- Followed the existing formatting
- The tool is free and publicly accessible

Thanks for maintaining this list! 🎨
