### PR TITLE
Add ColorTools to Web App

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ with AI-Powered Palette Generator.
 - [ColorBeta](https://colorbeta.com/) - Advanced CSS Gradient Generator.
 - [Color Wheel](https://colorwheel.co/) - A color wheel based on the drawings by Goethe, Johann Wolfgang von from the year 1810.
 - [RGB HEX Code](https://rgbhexcode.com/) - HTML/CSS Color Picker & Converter.
+- [ColorTools](https://colorpicker.cx/) - Free color picker from image, color wheel, palette generator, CSS gradient builder and WCAG contrast checker.
 
 ## Color Palettes
 - [ColorHunt](http://colorhunt.co/) - Color palettes with quick preview feature.


### PR DESCRIPTION
Adds ColorTools (https://colorpicker.cx/) to the Web App section - a free, no sign-up suite of color tools: image color picker, color wheel with harmony rules, palette generator, CSS gradient builder and WCAG contrast checker. Everything runs client-side.