### PR TITLE
Add ColorTools to Tools - Web App

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ with AI-Powered Palette Generator.
 - [ColorBeta](https://colorbeta.com/) - Advanced CSS Gradient Generator.
 - [Color Wheel](https://colorwheel.co/) - A color wheel based on the drawings by Goethe, Johann Wolfgang von from the year 1810.
 - [RGB HEX Code](https://rgbhexcode.com/) - HTML/CSS Color Picker & Converter.
+- [ColorTools](https://colorpicker.cx) - Free browser-based color picker, wheel, palette generator, gradient builder and WCAG contrast checker.
 
 ## Color Palettes
 - [ColorHunt](http://colorhunt.co/) - Color palettes with quick preview feature.


### PR DESCRIPTION
Adds ColorTools (colorpicker.cx) to the Tools → Web App section: a free, client-side color picker, color wheel, palette generator, CSS gradient builder and WCAG/APCA contrast checker. No signup, no ads.